### PR TITLE
MastResolver creates correct URL now

### DIFF
--- a/caom2-artifact-resolvers/build.gradle
+++ b/caom2-artifact-resolvers/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.1.1'
+version = '1.1.2'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/caom2-artifact-resolvers/src/intTest/java/ca/nrc/cadc/caom2/artifact/resolvers/MastResolverIntTest.java
+++ b/caom2-artifact-resolvers/src/intTest/java/ca/nrc/cadc/caom2/artifact/resolvers/MastResolverIntTest.java
@@ -105,12 +105,17 @@ public class MastResolverIntTest {
             URI mastUri = new URI(VALID_URI);
             URL url = mastResolver.toURL(mastUri);
 
-            log.debug("opening connection to: " + url.toString());
+            log.info("opening connection to: " + url.toString());
 
             OutputStream out = new ByteArrayOutputStream();
             HttpDownload head = new HttpDownload(url, out);
             head.setHeadOnly(true);
             head.run();
+            log.debug(head.getThrowable());
+            log.debug(out.toString());
+            // This call has been known to return a 400 on occasion, so this could fail.
+            // It seems to be something on their side, because with curl a URL will return 200
+            // for a HEAD call, and this call will return a 400.
             Assert.assertEquals(200, head.getResponseCode());
             log.info("response code: " + head.getResponseCode());
         } catch (Exception unexpected) {

--- a/caom2-artifact-resolvers/src/main/java/ca/nrc/cadc/caom2/artifact/resolvers/MastResolver.java
+++ b/caom2-artifact-resolvers/src/main/java/ca/nrc/cadc/caom2/artifact/resolvers/MastResolver.java
@@ -82,8 +82,7 @@ import org.apache.log4j.Logger;
 public class MastResolver implements StorageResolver {
 
     public static final String SCHEME = "mast";
-    private static final Logger log = Logger.getLogger(MastResolver.class);
-    private static final String MAST_BASE_ARTIFACT_URL = "http://mastpartners.stsci.edu/portal/Download/file";
+    private static final String MAST_BASE_ARTIFACT_URL = "http://mastpartners.stsci.edu/portal/Download/file/";
 
     public MastResolver() {
     }

--- a/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/ChandraResolverTest.java
+++ b/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/ChandraResolverTest.java
@@ -121,7 +121,7 @@ public class ChandraResolverTest {
                 URI uri = new URI(SCHEME + ":" + path);
                 URL url = chandraResolver.toURL(uri);
 
-                log.info("toURL returned: " + url.toString());
+                log.debug("toURL returned: " + url.toString());
                 Assert.assertTrue(url.toString().equals( PROTOCOL_STR + "://" + BASE_ARTIFACT_URL + BASE_PATH + uri.getSchemeSpecificPart()));
                 Assert.assertEquals(BASE_ARTIFACT_URL, url.getHost());
                 Assert.assertEquals(BASE_PATH + path, url.getPath());

--- a/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/ChandraResolverTest.java
+++ b/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/ChandraResolverTest.java
@@ -98,6 +98,7 @@ public class ChandraResolverTest {
     String BASE_ARTIFACT_URL = "cda.cfa.harvard.edu";
     String BASE_PATH = "/pub/byobsid/";
 
+
     // There are no tests that will validate the content of the
     // path other than empty.
     String INVALID_URI_BAD_SCHEME = "gemini:FOO/Bar";
@@ -120,6 +121,8 @@ public class ChandraResolverTest {
                 URI uri = new URI(SCHEME + ":" + path);
                 URL url = chandraResolver.toURL(uri);
 
+                log.info("toURL returned: " + url.toString());
+                Assert.assertTrue(url.toString().equals( PROTOCOL_STR + "://" + BASE_ARTIFACT_URL + BASE_PATH + uri.getSchemeSpecificPart()));
                 Assert.assertEquals(BASE_ARTIFACT_URL, url.getHost());
                 Assert.assertEquals(BASE_PATH + path, url.getPath());
                 Assert.assertEquals(PROTOCOL_STR, url.getProtocol());

--- a/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/GeminiResolverTest.java
+++ b/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/GeminiResolverTest.java
@@ -114,6 +114,8 @@ public class GeminiResolverTest {
             URI uri = new URI(uriStr);
             URL url = geminiResolver.toURL(uri);
 
+            log.info("toURL returned: " + url.toString());
+            Assert.assertEquals(url.toString(),PROTOCOL_STR + "://" + BASE_URL + "/file/" + VALID_FILE1);
             Assert.assertEquals("/" + uri.getSchemeSpecificPart(), url.getPath());
             Assert.assertEquals(BASE_URL, url.getHost());
 
@@ -122,6 +124,8 @@ public class GeminiResolverTest {
             uri = new URI(uriStr);
             url = geminiResolver.toURL(uri);
 
+            log.info("toURL returned: " + url.toString());
+            Assert.assertEquals(url.toString(), PROTOCOL_STR + "://" + BASE_URL + "/file/" + VALID_FILE2);
             Assert.assertEquals("/" + uri.getSchemeSpecificPart(), url.getPath());
             Assert.assertEquals(BASE_URL, url.getHost());
 

--- a/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/GeminiResolverTest.java
+++ b/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/GeminiResolverTest.java
@@ -114,7 +114,7 @@ public class GeminiResolverTest {
             URI uri = new URI(uriStr);
             URL url = geminiResolver.toURL(uri);
 
-            log.info("toURL returned: " + url.toString());
+            log.debug("toURL returned: " + url.toString());
             Assert.assertEquals(url.toString(),PROTOCOL_STR + "://" + BASE_URL + "/file/" + VALID_FILE1);
             Assert.assertEquals("/" + uri.getSchemeSpecificPart(), url.getPath());
             Assert.assertEquals(BASE_URL, url.getHost());
@@ -124,7 +124,7 @@ public class GeminiResolverTest {
             uri = new URI(uriStr);
             url = geminiResolver.toURL(uri);
 
-            log.info("toURL returned: " + url.toString());
+            log.debug("toURL returned: " + url.toString());
             Assert.assertEquals(url.toString(), PROTOCOL_STR + "://" + BASE_URL + "/file/" + VALID_FILE2);
             Assert.assertEquals("/" + uri.getSchemeSpecificPart(), url.getPath());
             Assert.assertEquals(BASE_URL, url.getHost());

--- a/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/MastResolverTest.java
+++ b/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/MastResolverTest.java
@@ -123,7 +123,7 @@ public class MastResolverTest {
                 URL url = mastResolver.toURL(uri);
                 String schemeSpecificPart = uri.getSchemeSpecificPart();
 
-                log.info("toURL returned: " + url.toString());
+                log.debug("toURL returned: " + url.toString());
                 Assert.assertTrue(url.toString().equals( MAST_BASE_URL + schemeSpecificPart));
                 Assert.assertTrue(url.getPath().endsWith(schemeSpecificPart));
             }

--- a/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/MastResolverTest.java
+++ b/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/MastResolverTest.java
@@ -94,6 +94,7 @@ public class MastResolverTest {
     String VALID_URI = "mast:FOO";
     String VALID_URI2 = "mast:FOO/bar";
     String PROTOCOL_STR = "https";
+    String MAST_BASE_URL = "http://mastpartners.stsci.edu/portal/Download/file/";
 
     // There are no tests that will validate the content of the
     // path other than empty.
@@ -102,7 +103,6 @@ public class MastResolverTest {
     MastResolver mastResolver = new MastResolver();
 
     public MastResolverTest() {
-
     }
 
     @Test
@@ -121,8 +121,11 @@ public class MastResolverTest {
 
                 URI uri = new URI(uriStr);
                 URL url = mastResolver.toURL(uri);
+                String schemeSpecificPart = uri.getSchemeSpecificPart();
 
-                Assert.assertTrue(url.getPath().endsWith(uri.getSchemeSpecificPart()));
+                log.info("toURL returned: " + url.toString());
+                Assert.assertTrue(url.toString().equals( MAST_BASE_URL + schemeSpecificPart));
+                Assert.assertTrue(url.getPath().endsWith(schemeSpecificPart));
             }
         } catch (Exception unexpected) {
             log.error("unexpected exception", unexpected);

--- a/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/NoaoResolverTest.java
+++ b/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/NoaoResolverTest.java
@@ -125,6 +125,9 @@ public class NoaoResolverTest {
                 URL url = noaoResolver.toURL(uri);
 
                 // NOAO uses '?' to POST scheme specific part of the URI to the server
+                log.info("toURL returned: " + url.toString());
+
+                Assert.assertEquals(url.toString(),PROTOCOL_STR + "://" + BASE_ARTIFACT_URL + ":7003/?" + URL_QUERY + uri.getSchemeSpecificPart() );
                 Assert.assertEquals(URL_QUERY + uri.getSchemeSpecificPart(), url.getQuery());
                 Assert.assertEquals(BASE_ARTIFACT_URL, url.getHost());
                 Assert.assertEquals(BASE_PATH, url.getPath());

--- a/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/NoaoResolverTest.java
+++ b/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/NoaoResolverTest.java
@@ -125,7 +125,7 @@ public class NoaoResolverTest {
                 URL url = noaoResolver.toURL(uri);
 
                 // NOAO uses '?' to POST scheme specific part of the URI to the server
-                log.info("toURL returned: " + url.toString());
+                log.debug("toURL returned: " + url.toString());
 
                 Assert.assertEquals(url.toString(),PROTOCOL_STR + "://" + BASE_ARTIFACT_URL + ":7003/?" + URL_QUERY + uri.getSchemeSpecificPart() );
                 Assert.assertEquals(URL_QUERY + uri.getSchemeSpecificPart(), url.getQuery());

--- a/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/SdssResolverTest.java
+++ b/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/SdssResolverTest.java
@@ -69,15 +69,24 @@
 
 package ca.nrc.cadc.caom2.artifact.resolvers;
 
+import ca.nrc.cadc.util.Log4jInit;
 import java.net.URI;
 import java.net.URL;
 
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
 
 public class SdssResolverTest {
+
+    public SdssResolverTest() {
+    }
 
     @Test
     public void getScheme() {

--- a/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/SmokaResolverTest.java
+++ b/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/SmokaResolverTest.java
@@ -128,7 +128,7 @@ public class SmokaResolverTest {
             String uriStr = smokaResolver.getScheme() + ":" + FILE_URI + "/" + VALID_FILE1;
             URI uri = new URI(uriStr);
             URL url = smokaResolver.toURL(uri);
-            log.info("toURL returned: " + url.toString());
+            log.debug("toURL returned: " + url.toString());
 
             Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_URL + FILE_URL_PATH + "?" + FILE_URL_QUERY + VALID_FILE2);
             Assert.assertEquals(FILE_URL_PATH, url.getPath());
@@ -139,7 +139,7 @@ public class SmokaResolverTest {
             uriStr = smokaResolver.getScheme() + ":" + PREVIEW_URI + "/" + VALID_FILE2;
             uri = new URI(uriStr);
             url = smokaResolver.toURL(uri);
-            log.info("toURL returned: " + url.toString());
+            log.debug("toURL returned: " + url.toString());
             // http://smoka.nao.ac.jp/qlis/ImagePNG?grayscale=linear&mosaic=true&frameid=SUPE01318470
 
             Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_URL + PREVIEW_URL_PATH + "?" + PREVIEW_URL_QUERY + VALID_FILE2);

--- a/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/SmokaResolverTest.java
+++ b/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/SmokaResolverTest.java
@@ -107,6 +107,7 @@ public class SmokaResolverTest {
     String PREVIEW_URL_QUERY = "grayscale=linear&mosaic=true&frameid=";
     String FILE_URL_PATH = "/fssearch";
     String PREVIEW_URL_PATH = "/qlis/ImagePNG";
+    String PROTOCOL_STR = "http://";
 
     // Invalid checks the scheme and the request type (needs to be 'file' or 'preview'
     String INVALID_URI_BAD_SCHEME = "pokey:little/puppy";
@@ -127,7 +128,9 @@ public class SmokaResolverTest {
             String uriStr = smokaResolver.getScheme() + ":" + FILE_URI + "/" + VALID_FILE1;
             URI uri = new URI(uriStr);
             URL url = smokaResolver.toURL(uri);
+            log.info("toURL returned: " + url.toString());
 
+            Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_URL + FILE_URL_PATH + "?" + FILE_URL_QUERY + VALID_FILE2);
             Assert.assertEquals(FILE_URL_PATH, url.getPath());
             Assert.assertEquals(FILE_URL_QUERY + VALID_FILE1, url.getQuery());
             Assert.assertEquals(BASE_URL, url.getHost());
@@ -136,7 +139,10 @@ public class SmokaResolverTest {
             uriStr = smokaResolver.getScheme() + ":" + PREVIEW_URI + "/" + VALID_FILE2;
             uri = new URI(uriStr);
             url = smokaResolver.toURL(uri);
+            log.info("toURL returned: " + url.toString());
+            // http://smoka.nao.ac.jp/qlis/ImagePNG?grayscale=linear&mosaic=true&frameid=SUPE01318470
 
+            Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_URL + PREVIEW_URL_PATH + "?" + PREVIEW_URL_QUERY + VALID_FILE2);
             Assert.assertEquals(PREVIEW_URL_PATH, url.getPath());
             Assert.assertEquals(PREVIEW_URL_QUERY + VALID_FILE2, url.getQuery());
             Assert.assertEquals(BASE_URL, url.getHost());

--- a/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/XmmResolverTest.java
+++ b/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/XmmResolverTest.java
@@ -121,7 +121,7 @@ public class XmmResolverTest {
             for (String uriStr : validURIs) {
                 URI uri = new URI(uriStr);
                 URL url = xmmResolver.toURL(uri);
-                log.info("toURL returned: " + url.toString());
+                log.debug("toURL returned: " + url.toString());
 
                 // XMM uses '?' to POST scheme specific part of the URI to the server
                 //  example url: http://nxsa.esac.esa.int/nxsa-sl/servlet/data-action-aio?FOO

--- a/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/XmmResolverTest.java
+++ b/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/XmmResolverTest.java
@@ -121,8 +121,11 @@ public class XmmResolverTest {
             for (String uriStr : validURIs) {
                 URI uri = new URI(uriStr);
                 URL url = xmmResolver.toURL(uri);
+                log.info("toURL returned: " + url.toString());
 
                 // XMM uses '?' to POST scheme specific part of the URI to the server
+                //  example url: http://nxsa.esac.esa.int/nxsa-sl/servlet/data-action-aio?FOO
+                Assert.assertEquals(url.toString(),PROTOCOL_STR + "://" + BASE_ARTIFACT_URL + BASE_PATH + "?" + uri.getSchemeSpecificPart() );
                 Assert.assertEquals(uri.getSchemeSpecificPart(), url.getQuery());
                 Assert.assertEquals(BASE_ARTIFACT_URL, url.getHost());
                 Assert.assertEquals(BASE_PATH, url.getPath());


### PR DESCRIPTION
 + updates to resolver unit tests to check for full URL string.