### PR TITLE
Allow Preview URIs that don't fully conform.

### DIFF
--- a/caom2-artifact-resolvers/build.gradle
+++ b/caom2-artifact-resolvers/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'maven'
     id 'maven-publish'
-    id 'com.jfrog.bintray' version '1.7.3'
+    id 'com.jfrog.bintray' version '1.8.0'
     id 'checkstyle'
 }
 
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.1.4'
+version = '1.1.5'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/caom2-artifact-resolvers/src/main/java/ca/nrc/cadc/caom2/artifact/resolvers/SubaruResolver.java
+++ b/caom2-artifact-resolvers/src/main/java/ca/nrc/cadc/caom2/artifact/resolvers/SubaruResolver.java
@@ -31,9 +31,11 @@ package ca.nrc.cadc.caom2.artifact.resolvers;
 import ca.nrc.cadc.caom2.artifact.resolvers.util.ResolverUtil;
 import ca.nrc.cadc.net.NetUtil;
 import ca.nrc.cadc.net.StorageResolver;
+
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+
 import org.apache.log4j.Logger;
 
 /**
@@ -72,36 +74,45 @@ public class SubaruResolver implements StorageResolver {
     /**
      * Validate path portion of URI for structure and create URL if possible
      *
-     * @param uri
-     * @return URL
+     * @param uri       The URI of the given artifact.
+     * @return URL      The converted URL.
      * @throws IllegalArgumentException if the scheme is not equal to the value from getScheme()
      *                                  the uri is malformed such that a URL cannot be generated, or the uri is null
      */
-    private URL createURLFromPath(URI uri) {
-        URL newUrl = null;
-        String[] path = uri.getSchemeSpecificPart().split("/");
+    private URL createURLFromPath(final URI uri) {
+        final String[] path = uri.getSchemeSpecificPart().split("/");
         // data uri has 3 parts, preview has 2
 
         if (path.length < 2 || path.length > 3) {
             throw new IllegalArgumentException("Malformed URI. Expected 2 or 3 path components, found " + path.length);
         }
 
-        String sb = "";
-        String requestType = path[0];
-        if (path.length == 2 && requestType.equals(PREVIEW_URI)) {
+        final String sb;
+        final String requestType = path[0];
+
+        // Changes here to the Preview URI are just to prevent an IllegalArgument for Preview URIs that do not conform
+        // to the old values.
+        //
+        // Will be fixed properly in Story 2287.
+        //
+        // jenkinsd 2018.04.23
+        //
+        if (requestType.equals(PREVIEW_URI)) {
             // Returns a web page reference
             // expected URI input is subaru:preview/<FRAMEID>
-            sb = PREVIEW_BASE_URL + "?" + PREVIEW_URL_QUERY + path[1];
+            sb = PREVIEW_BASE_URL + "?" + PREVIEW_URL_QUERY
+                + ((path.length == 3) ? NetUtil.encode(path[2] + " " + path[1]) : path[1]);
         } else if (path.length == 3 && requestType.equals(RAW_DATA_URI)) {
             // expected URI input is subaru:raw/YYYY-MM-dd/<FRAMEID>
-            // expected URL output is http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/maq/subaru?frameinfo=YYYY-MM-dd/FRAMEID
-            sb = BASE_DATA_URL +  NetUtil.encode(path[1] + "/" + path[2]);
+            // expected URL output is http://www.cadc-ccda.hia-iha.nrc-cnrc.gc
+            // .ca/maq/subaru?frameinfo=YYYY-MM-dd/FRAMEID
+            sb = BASE_DATA_URL + NetUtil.encode(path[1] + "/" + path[2]);
         } else {
             throw new IllegalArgumentException("Invalid URI: " + requestType);
         }
 
         try {
-            newUrl = new URL(sb);
+            final URL newUrl = new URL(sb);
             log.debug(uri + " --> " + newUrl);
             return newUrl;
         } catch (MalformedURLException ex) {

--- a/caom2-artifact-resolvers/src/main/java/ca/nrc/cadc/caom2/artifact/resolvers/SubaruResolver.java
+++ b/caom2-artifact-resolvers/src/main/java/ca/nrc/cadc/caom2/artifact/resolvers/SubaruResolver.java
@@ -2,7 +2,7 @@
  ************************************************************************
  ****  C A N A D I A N   A S T R O N O M Y   D A T A   C E N T R E  *****
  *
- * (c) 2017.                            (c) 2017.
+ * (c) 2018.                            (c) 2018.
  * National Research Council            Conseil national de recherches
  * Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
  * All rights reserved                  Tous droits reserves

--- a/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/SubaruResolverTest.java
+++ b/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/SubaruResolverTest.java
@@ -71,10 +71,8 @@ package ca.nrc.cadc.caom2.artifact.resolvers;
 
 import ca.nrc.cadc.net.NetUtil;
 import ca.nrc.cadc.util.Log4jInit;
-
 import java.net.URI;
 import java.net.URL;
-
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
@@ -106,7 +104,7 @@ public class SubaruResolverTest {
 
     String BASE_DATA_URL = "www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca";
     String DATA_URL_PATH = "/maq/subaru";
-    String DATA_URL_QUERY = "frameinfo=";
+    String DATA_URL_QUERY= "frameinfo=";
 
     // Invalid checks the scheme and the request type (needs to be 'file' or 'preview')
     String INVALID_URI_BAD_SCHEME = "pokey:little/puppy";
@@ -118,50 +116,37 @@ public class SubaruResolverTest {
 
     @Test
     public void testGetSchema() {
-        Assert.assertTrue(subaruResolver.getScheme().equals(subaruResolver.getScheme()));
+        Assert.assertEquals(subaruResolver.getScheme(), subaruResolver.getScheme());
     }
 
     @Test
-    public void testValidURI() {
-        String uriStr = subaruResolver.getScheme() + ":" + RAW_DATA_URI + "/" + VALID_DATE1 + "/" + VALID_FILE1;
-        URI uri = URI.create(uriStr);
-        URL url = subaruResolver.toURL(uri);
-        log.debug("toURL returned: " + url.toString());
+    public void testValidURI() throws Exception {
+        try {
+            String uriStr = subaruResolver.getScheme() + ":" + RAW_DATA_URI + "/" + VALID_DATE1 + "/" + VALID_FILE1;
+            URI uri = new URI(uriStr);
+            URL url = subaruResolver.toURL(uri);
+            log.debug("toURL returned: " + url.toString());
 
-        String encodedValue = NetUtil.encode(VALID_DATE1 + "/" + VALID_FILE1);
-        Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_DATA_URL + DATA_URL_PATH + "?" + DATA_URL_QUERY +
-            encodedValue);
-        Assert.assertEquals(DATA_URL_PATH, url.getPath());
-        Assert.assertEquals(DATA_URL_QUERY + encodedValue, url.getQuery());
-        Assert.assertEquals(BASE_DATA_URL, url.getHost());
+            String encodedValue = NetUtil.encode(VALID_DATE1 + "/" + VALID_FILE1);
+            Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_DATA_URL + DATA_URL_PATH + "?" + DATA_URL_QUERY +  encodedValue);
+            Assert.assertEquals(DATA_URL_PATH, url.getPath());
+            Assert.assertEquals(DATA_URL_QUERY + encodedValue, url.getQuery());
+            Assert.assertEquals(BASE_DATA_URL, url.getHost());
 
-        uriStr = subaruResolver.getScheme() + ":" + PREVIEW_URI + "/" + VALID_FILE2;
-        uri = URI.create(uriStr);
-        url = subaruResolver.toURL(uri);
-        log.debug("toURL returned: " + url.toString());
+            uriStr = subaruResolver.getScheme() + ":" + PREVIEW_URI + "/" + VALID_FILE2;
+            uri = new URI(uriStr);
+            url = subaruResolver.toURL(uri);
+            log.debug("toURL returned: " + url.toString());
 
-        Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_PREVIEW_URL + PREVIEW_URL_PATH + "?" +
-            PREVIEW_URL_QUERY + VALID_FILE2);
-        Assert.assertEquals(PREVIEW_URL_PATH, url.getPath());
-        Assert.assertEquals(PREVIEW_URL_QUERY + VALID_FILE2, url.getQuery());
-        Assert.assertEquals(BASE_PREVIEW_URL, url.getHost());
-    }
+            Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_PREVIEW_URL + PREVIEW_URL_PATH + "?" + PREVIEW_URL_QUERY + VALID_FILE2);
+            Assert.assertEquals(PREVIEW_URL_PATH, url.getPath());
+            Assert.assertEquals(PREVIEW_URL_QUERY + VALID_FILE2, url.getQuery());
+            Assert.assertEquals(BASE_PREVIEW_URL, url.getHost());
 
-    @Test
-    public void testValidPreviewURI() {
-        final String uriStr = subaruResolver.getScheme() + ":" + PREVIEW_URI + "/" + VALID_DATE1 + "/" + VALID_FILE2;
-        final URI uri = URI.create(uriStr);
-        final URL url = subaruResolver.toURL(uri);
-
-        log.debug("toURL returned: " + url.toString());
-
-        String encodedValue = NetUtil.encode(VALID_FILE2 + " " + VALID_DATE1);
-
-        Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_PREVIEW_URL + PREVIEW_URL_PATH + "?" +
-            PREVIEW_URL_QUERY + encodedValue);
-        Assert.assertEquals(PREVIEW_URL_PATH, url.getPath());
-        Assert.assertEquals(PREVIEW_URL_QUERY + encodedValue, url.getQuery());
-        Assert.assertEquals(BASE_PREVIEW_URL, url.getHost());
+        } catch (Exception unexpected) {
+            log.error("unexpected exception", unexpected);
+            throw unexpected;
+        }
     }
 
     @Test
@@ -172,6 +157,32 @@ public class SubaruResolverTest {
             Assert.fail("expected IllegalArgumentException, got " + url);
         } catch (IllegalArgumentException expected) {
             log.info("IllegalArgumentException thrown as expected. Test passed.: " + expected);
+        } catch (Exception unexpected) {
+            log.error("unexpected exception", unexpected);
+            throw unexpected;
+        }
+    }
+
+    @Test
+    public void testValidPreviewURI() {
+        try {
+            final String uriStr = subaruResolver.getScheme() + ":" + PREVIEW_URI + "/" + VALID_DATE1 + "/" + VALID_FILE2;
+
+            final URI uri = URI.create(uriStr);
+            final URL url = subaruResolver.toURL(uri);
+
+            log.debug("toURL returned: " + url.toString());
+
+            String encodedValue = NetUtil.encode(VALID_FILE2 + " " + VALID_DATE1);
+
+            Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_PREVIEW_URL + PREVIEW_URL_PATH + "?" +
+                PREVIEW_URL_QUERY + encodedValue);
+            Assert.assertEquals(PREVIEW_URL_PATH, url.getPath());
+            Assert.assertEquals(PREVIEW_URL_QUERY + encodedValue, url.getQuery());
+            Assert.assertEquals(BASE_PREVIEW_URL, url.getHost());
+        } catch (Exception e) {
+            log.error("unexpected exception", e);
+            throw e;
         }
     }
 
@@ -182,18 +193,24 @@ public class SubaruResolverTest {
             Assert.fail("expected IllegalArgumentException, got " + url);
         } catch (IllegalArgumentException expected) {
             log.info("IllegalArgumentException thrown as expected. Test passed.: " + expected);
+        } catch (Exception unexpected) {
+            log.error("unexpected exception", unexpected);
+            throw unexpected;
         }
     }
 
     @Test
-    public void testInvalidUriType() {
+    public void testInvalidUriType() throws Exception {
         try {
             String uriStr = GeminiResolver.SCHEME + ":badURIType/" + VALID_FILE1;
-            URI uri = URI.create(uriStr);
+            URI uri = new URI(uriStr);
             URL url = subaruResolver.toURL(uri);
             Assert.fail("expected IllegalArgumentException, got " + url);
         } catch (IllegalArgumentException expected) {
             log.info("IllegalArgumentException thrown as expected. Test passed.: " + expected);
+        } catch (Exception unexpected) {
+            log.error("unexpected exception", unexpected);
+            throw unexpected;
         }
     }
 

--- a/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/SubaruResolverTest.java
+++ b/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/SubaruResolverTest.java
@@ -1,78 +1,80 @@
 /*
-************************************************************************
-*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
-**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
-*
-*  (c) 2017.                            (c) 2017.
-*  Government of Canada                 Gouvernement du Canada
-*  National Research Council            Conseil national de recherches
-*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-*  All rights reserved                  Tous droits réservés
-*
-*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
-*  expressed, implied, or               énoncée, implicite ou légale,
-*  statutory, of any kind with          de quelque nature que ce
-*  respect to the software,             soit, concernant le logiciel,
-*  including without limitation         y compris sans restriction
-*  any warranty of merchantability      toute garantie de valeur
-*  or fitness for a particular          marchande ou de pertinence
-*  purpose. NRC shall not be            pour un usage particulier.
-*  liable in any event for any          Le CNRC ne pourra en aucun cas
-*  damages, whether direct or           être tenu responsable de tout
-*  indirect, special or general,        dommage, direct ou indirect,
-*  consequential or incidental,         particulier ou général,
-*  arising from the use of the          accessoire ou fortuit, résultant
-*  software.  Neither the name          de l'utilisation du logiciel. Ni
-*  of the National Research             le nom du Conseil National de
-*  Council of Canada nor the            Recherches du Canada ni les noms
-*  names of its contributors may        de ses  participants ne peuvent
-*  be used to endorse or promote        être utilisés pour approuver ou
-*  products derived from this           promouvoir les produits dérivés
-*  software without specific prior      de ce logiciel sans autorisation
-*  written permission.                  préalable et particulière
-*                                       par écrit.
-*
-*  This file is part of the             Ce fichier fait partie du projet
-*  OpenCADC project.                    OpenCADC.
-*
-*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
-*  you can redistribute it and/or       vous pouvez le redistribuer ou le
-*  modify it under the terms of         modifier suivant les termes de
-*  the GNU Affero General Public        la “GNU Affero General Public
-*  License as published by the          License” telle que publiée
-*  Free Software Foundation,            par la Free Software Foundation
-*  either version 3 of the              : soit la version 3 de cette
-*  License, or (at your option)         licence, soit (à votre gré)
-*  any later version.                   toute version ultérieure.
-*
-*  OpenCADC is distributed in the       OpenCADC est distribué
-*  hope that it will be useful,         dans l’espoir qu’il vous
-*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
-*  without even the implied             GARANTIE : sans même la garantie
-*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
-*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
-*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
-*  General Public License for           Générale Publique GNU Affero
-*  more details.                        pour plus de détails.
-*
-*  You should have received             Vous devriez avoir reçu une
-*  a copy of the GNU Affero             copie de la Licence Générale
-*  General Public License along         Publique GNU Affero avec
-*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
-*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
-*                                       <http://www.gnu.org/licenses/>.
-*
-*  $Revision: 5 $
-*
-************************************************************************
-*/
+ ************************************************************************
+ *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+ **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+ *
+ *  (c) 2017.                            (c) 2017.
+ *  Government of Canada                 Gouvernement du Canada
+ *  National Research Council            Conseil national de recherches
+ *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+ *  All rights reserved                  Tous droits réservés
+ *
+ *  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+ *  expressed, implied, or               énoncée, implicite ou légale,
+ *  statutory, of any kind with          de quelque nature que ce
+ *  respect to the software,             soit, concernant le logiciel,
+ *  including without limitation         y compris sans restriction
+ *  any warranty of merchantability      toute garantie de valeur
+ *  or fitness for a particular          marchande ou de pertinence
+ *  purpose. NRC shall not be            pour un usage particulier.
+ *  liable in any event for any          Le CNRC ne pourra en aucun cas
+ *  damages, whether direct or           être tenu responsable de tout
+ *  indirect, special or general,        dommage, direct ou indirect,
+ *  consequential or incidental,         particulier ou général,
+ *  arising from the use of the          accessoire ou fortuit, résultant
+ *  software.  Neither the name          de l'utilisation du logiciel. Ni
+ *  of the National Research             le nom du Conseil National de
+ *  Council of Canada nor the            Recherches du Canada ni les noms
+ *  names of its contributors may        de ses  participants ne peuvent
+ *  be used to endorse or promote        être utilisés pour approuver ou
+ *  products derived from this           promouvoir les produits dérivés
+ *  software without specific prior      de ce logiciel sans autorisation
+ *  written permission.                  préalable et particulière
+ *                                       par écrit.
+ *
+ *  This file is part of the             Ce fichier fait partie du projet
+ *  OpenCADC project.                    OpenCADC.
+ *
+ *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+ *  you can redistribute it and/or       vous pouvez le redistribuer ou le
+ *  modify it under the terms of         modifier suivant les termes de
+ *  the GNU Affero General Public        la “GNU Affero General Public
+ *  License as published by the          License” telle que publiée
+ *  Free Software Foundation,            par la Free Software Foundation
+ *  either version 3 of the              : soit la version 3 de cette
+ *  License, or (at your option)         licence, soit (à votre gré)
+ *  any later version.                   toute version ultérieure.
+ *
+ *  OpenCADC is distributed in the       OpenCADC est distribué
+ *  hope that it will be useful,         dans l’espoir qu’il vous
+ *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+ *  without even the implied             GARANTIE : sans même la garantie
+ *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+ *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+ *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+ *  General Public License for           Générale Publique GNU Affero
+ *  more details.                        pour plus de détails.
+ *
+ *  You should have received             Vous devriez avoir reçu une
+ *  a copy of the GNU Affero             copie de la Licence Générale
+ *  General Public License along         Publique GNU Affero avec
+ *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+ *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+ *                                       <http://www.gnu.org/licenses/>.
+ *
+ *  $Revision: 5 $
+ *
+ ************************************************************************
+ */
 
 package ca.nrc.cadc.caom2.artifact.resolvers;
 
 import ca.nrc.cadc.net.NetUtil;
 import ca.nrc.cadc.util.Log4jInit;
+
 import java.net.URI;
 import java.net.URL;
+
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
@@ -104,7 +106,7 @@ public class SubaruResolverTest {
 
     String BASE_DATA_URL = "www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca";
     String DATA_URL_PATH = "/maq/subaru";
-    String DATA_URL_QUERY= "frameinfo=";
+    String DATA_URL_QUERY = "frameinfo=";
 
     // Invalid checks the scheme and the request type (needs to be 'file' or 'preview')
     String INVALID_URI_BAD_SCHEME = "pokey:little/puppy";
@@ -121,45 +123,55 @@ public class SubaruResolverTest {
 
     @Test
     public void testValidURI() {
-        try {
-            String uriStr = subaruResolver.getScheme() + ":" + RAW_DATA_URI + "/" + VALID_DATE1 + "/" + VALID_FILE1;
-            URI uri = new URI(uriStr);
-            URL url = subaruResolver.toURL(uri);
-            log.debug("toURL returned: " + url.toString());
+        String uriStr = subaruResolver.getScheme() + ":" + RAW_DATA_URI + "/" + VALID_DATE1 + "/" + VALID_FILE1;
+        URI uri = URI.create(uriStr);
+        URL url = subaruResolver.toURL(uri);
+        log.debug("toURL returned: " + url.toString());
 
-            String encodedValue = NetUtil.encode(VALID_DATE1 + "/" + VALID_FILE1);
-            Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_DATA_URL + DATA_URL_PATH + "?" + DATA_URL_QUERY +  encodedValue);
-            Assert.assertEquals(DATA_URL_PATH, url.getPath());
-            Assert.assertEquals(DATA_URL_QUERY + encodedValue, url.getQuery());
-            Assert.assertEquals(BASE_DATA_URL, url.getHost());
+        String encodedValue = NetUtil.encode(VALID_DATE1 + "/" + VALID_FILE1);
+        Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_DATA_URL + DATA_URL_PATH + "?" + DATA_URL_QUERY +
+            encodedValue);
+        Assert.assertEquals(DATA_URL_PATH, url.getPath());
+        Assert.assertEquals(DATA_URL_QUERY + encodedValue, url.getQuery());
+        Assert.assertEquals(BASE_DATA_URL, url.getHost());
 
-            uriStr = subaruResolver.getScheme() + ":" + PREVIEW_URI + "/" + VALID_FILE2;
-            uri = new URI(uriStr);
-            url = subaruResolver.toURL(uri);
-            log.debug("toURL returned: " + url.toString());
+        uriStr = subaruResolver.getScheme() + ":" + PREVIEW_URI + "/" + VALID_FILE2;
+        uri = URI.create(uriStr);
+        url = subaruResolver.toURL(uri);
+        log.debug("toURL returned: " + url.toString());
 
-            Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_PREVIEW_URL + PREVIEW_URL_PATH + "?" + PREVIEW_URL_QUERY + VALID_FILE2);
-            Assert.assertEquals(PREVIEW_URL_PATH, url.getPath());
-            Assert.assertEquals(PREVIEW_URL_QUERY + VALID_FILE2, url.getQuery());
-            Assert.assertEquals(BASE_PREVIEW_URL, url.getHost());
-
-        } catch (Exception unexpected) {
-            log.error("unexpected exception", unexpected);
-            Assert.fail("unexpected exception: " + unexpected);
-        }
+        Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_PREVIEW_URL + PREVIEW_URL_PATH + "?" +
+            PREVIEW_URL_QUERY + VALID_FILE2);
+        Assert.assertEquals(PREVIEW_URL_PATH, url.getPath());
+        Assert.assertEquals(PREVIEW_URL_QUERY + VALID_FILE2, url.getQuery());
+        Assert.assertEquals(BASE_PREVIEW_URL, url.getHost());
     }
 
     @Test
-    public void testInvalidURIBadScheme() {
+    public void testValidPreviewURI() {
+        final String uriStr = subaruResolver.getScheme() + ":" + PREVIEW_URI + "/" + VALID_DATE1 + "/" + VALID_FILE2;
+        final URI uri = URI.create(uriStr);
+        final URL url = subaruResolver.toURL(uri);
+
+        log.debug("toURL returned: " + url.toString());
+
+        String encodedValue = NetUtil.encode(VALID_FILE2 + " " + VALID_DATE1);
+
+        Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_PREVIEW_URL + PREVIEW_URL_PATH + "?" +
+            PREVIEW_URL_QUERY + encodedValue);
+        Assert.assertEquals(PREVIEW_URL_PATH, url.getPath());
+        Assert.assertEquals(PREVIEW_URL_QUERY + encodedValue, url.getQuery());
+        Assert.assertEquals(BASE_PREVIEW_URL, url.getHost());
+    }
+
+    @Test
+    public void testInvalidURIBadScheme() throws Exception {
         try {
             URI uri = new URI(INVALID_URI_BAD_SCHEME);
             URL url = subaruResolver.toURL(uri);
             Assert.fail("expected IllegalArgumentException, got " + url);
         } catch (IllegalArgumentException expected) {
             log.info("IllegalArgumentException thrown as expected. Test passed.: " + expected);
-        } catch (Exception unexpected) {
-            log.error("unexpected exception", unexpected);
-            Assert.fail("unexpected exception: " + unexpected);
         }
     }
 
@@ -170,9 +182,6 @@ public class SubaruResolverTest {
             Assert.fail("expected IllegalArgumentException, got " + url);
         } catch (IllegalArgumentException expected) {
             log.info("IllegalArgumentException thrown as expected. Test passed.: " + expected);
-        } catch (Exception unexpected) {
-            log.error("unexpected exception", unexpected);
-            Assert.fail("unexpected exception: " + unexpected);
         }
     }
 
@@ -180,14 +189,11 @@ public class SubaruResolverTest {
     public void testInvalidUriType() {
         try {
             String uriStr = GeminiResolver.SCHEME + ":badURIType/" + VALID_FILE1;
-            URI uri = new URI(uriStr);
+            URI uri = URI.create(uriStr);
             URL url = subaruResolver.toURL(uri);
             Assert.fail("expected IllegalArgumentException, got " + url);
         } catch (IllegalArgumentException expected) {
             log.info("IllegalArgumentException thrown as expected. Test passed.: " + expected);
-        } catch (Exception unexpected) {
-            log.error("unexpected exception", unexpected);
-            Assert.fail("unexpected exception: " + unexpected);
         }
     }
 

--- a/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/SubaruResolverTest.java
+++ b/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/SubaruResolverTest.java
@@ -1,71 +1,71 @@
 /*
- ************************************************************************
- *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
- **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
- *
- *  (c) 2017.                            (c) 2017.
- *  Government of Canada                 Gouvernement du Canada
- *  National Research Council            Conseil national de recherches
- *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
- *  All rights reserved                  Tous droits réservés
- *
- *  NRC disclaims any warranties,        Le CNRC dénie toute garantie
- *  expressed, implied, or               énoncée, implicite ou légale,
- *  statutory, of any kind with          de quelque nature que ce
- *  respect to the software,             soit, concernant le logiciel,
- *  including without limitation         y compris sans restriction
- *  any warranty of merchantability      toute garantie de valeur
- *  or fitness for a particular          marchande ou de pertinence
- *  purpose. NRC shall not be            pour un usage particulier.
- *  liable in any event for any          Le CNRC ne pourra en aucun cas
- *  damages, whether direct or           être tenu responsable de tout
- *  indirect, special or general,        dommage, direct ou indirect,
- *  consequential or incidental,         particulier ou général,
- *  arising from the use of the          accessoire ou fortuit, résultant
- *  software.  Neither the name          de l'utilisation du logiciel. Ni
- *  of the National Research             le nom du Conseil National de
- *  Council of Canada nor the            Recherches du Canada ni les noms
- *  names of its contributors may        de ses  participants ne peuvent
- *  be used to endorse or promote        être utilisés pour approuver ou
- *  products derived from this           promouvoir les produits dérivés
- *  software without specific prior      de ce logiciel sans autorisation
- *  written permission.                  préalable et particulière
- *                                       par écrit.
- *
- *  This file is part of the             Ce fichier fait partie du projet
- *  OpenCADC project.                    OpenCADC.
- *
- *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
- *  you can redistribute it and/or       vous pouvez le redistribuer ou le
- *  modify it under the terms of         modifier suivant les termes de
- *  the GNU Affero General Public        la “GNU Affero General Public
- *  License as published by the          License” telle que publiée
- *  Free Software Foundation,            par la Free Software Foundation
- *  either version 3 of the              : soit la version 3 de cette
- *  License, or (at your option)         licence, soit (à votre gré)
- *  any later version.                   toute version ultérieure.
- *
- *  OpenCADC is distributed in the       OpenCADC est distribué
- *  hope that it will be useful,         dans l’espoir qu’il vous
- *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
- *  without even the implied             GARANTIE : sans même la garantie
- *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
- *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
- *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
- *  General Public License for           Générale Publique GNU Affero
- *  more details.                        pour plus de détails.
- *
- *  You should have received             Vous devriez avoir reçu une
- *  a copy of the GNU Affero             copie de la Licence Générale
- *  General Public License along         Publique GNU Affero avec
- *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
- *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
- *                                       <http://www.gnu.org/licenses/>.
- *
- *  $Revision: 5 $
- *
- ************************************************************************
- */
+************************************************************************
+*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+*
+*  (c) 2018.                            (c) 2018.
+*  Government of Canada                 Gouvernement du Canada
+*  National Research Council            Conseil national de recherches
+*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+*  All rights reserved                  Tous droits réservés
+*
+*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+*  expressed, implied, or               énoncée, implicite ou légale,
+*  statutory, of any kind with          de quelque nature que ce
+*  respect to the software,             soit, concernant le logiciel,
+*  including without limitation         y compris sans restriction
+*  any warranty of merchantability      toute garantie de valeur
+*  or fitness for a particular          marchande ou de pertinence
+*  purpose. NRC shall not be            pour un usage particulier.
+*  liable in any event for any          Le CNRC ne pourra en aucun cas
+*  damages, whether direct or           être tenu responsable de tout
+*  indirect, special or general,        dommage, direct ou indirect,
+*  consequential or incidental,         particulier ou général,
+*  arising from the use of the          accessoire ou fortuit, résultant
+*  software.  Neither the name          de l'utilisation du logiciel. Ni
+*  of the National Research             le nom du Conseil National de
+*  Council of Canada nor the            Recherches du Canada ni les noms
+*  names of its contributors may        de ses  participants ne peuvent
+*  be used to endorse or promote        être utilisés pour approuver ou
+*  products derived from this           promouvoir les produits dérivés
+*  software without specific prior      de ce logiciel sans autorisation
+*  written permission.                  préalable et particulière
+*                                       par écrit.
+*
+*  This file is part of the             Ce fichier fait partie du projet
+*  OpenCADC project.                    OpenCADC.
+*
+*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+*  you can redistribute it and/or       vous pouvez le redistribuer ou le
+*  modify it under the terms of         modifier suivant les termes de
+*  the GNU Affero General Public        la “GNU Affero General Public
+*  License as published by the          License” telle que publiée
+*  Free Software Foundation,            par la Free Software Foundation
+*  either version 3 of the              : soit la version 3 de cette
+*  License, or (at your option)         licence, soit (à votre gré)
+*  any later version.                   toute version ultérieure.
+*
+*  OpenCADC is distributed in the       OpenCADC est distribué
+*  hope that it will be useful,         dans l’espoir qu’il vous
+*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+*  without even the implied             GARANTIE : sans même la garantie
+*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+*  General Public License for           Générale Publique GNU Affero
+*  more details.                        pour plus de détails.
+*
+*  You should have received             Vous devriez avoir reçu une
+*  a copy of the GNU Affero             copie de la Licence Générale
+*  General Public License along         Publique GNU Affero avec
+*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+*                                       <http://www.gnu.org/licenses/>.
+*
+*  $Revision: 5 $
+*
+************************************************************************
+*/
 
 package ca.nrc.cadc.caom2.artifact.resolvers;
 


### PR DESCRIPTION
New Preview URIs are failing when the Resolver tries to create URLs because they have three items in the path, rather than two.  There are now a mix of two and three item path URIs, which prevents the
Download URLs from being generated.

A soon-to-be completed Story will fix them properly, but for now the Download URLs need to be generated regardless of Previews.  This fixes that.