### PR TITLE
Minimize dependencies and restrict versions to patches.

### DIFF
--- a/caom2-artifact-resolvers/build.gradle
+++ b/caom2-artifact-resolvers/build.gradle
@@ -20,8 +20,7 @@ version = '1.1.11'
 dependencies {
     compile 'log4j:log4j:1.2.+'
 
-    compile 'org.opencadc:cadc-util:[1.1,)'
-    compile 'org.opencadc:cadc-registry:[1.0,)'
+    compile 'org.opencadc:cadc-registry:1.4.+'
 
     testCompile 'junit:junit:4.+'
 }


### PR DESCRIPTION
In order to simplify the version dependencies, I have modified the dependencies to limit the version freedom to patches. I have also removed some (apparently) unneeded dependencies. Please, let me know your opinion.