### PR TITLE
alma-resolver-fix. Changed getStorageResolve() to public.

### DIFF
--- a/caom2-artifact-resolvers/build.gradle
+++ b/caom2-artifact-resolvers/build.gradle
@@ -15,15 +15,15 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.1.13'
+version = '1.1.14'
 
 dependencies {
-    compile 'log4j:log4j:1.2.+'
+    compile 'log4j:log4j:[1.2.0,)'
 
     compile 'org.opencadc:cadc-util:[1.1,)'
     compile 'org.opencadc:cadc-registry:[1.0,)'
 
-    testCompile 'junit:junit:4.+'
+    testCompile 'junit:junit:[4.0,)'
 }
 
 // enable intTest

--- a/caom2-artifact-resolvers/src/main/java/ca/nrc/cadc/caom2/artifact/resolvers/CaomArtifactResolver.java
+++ b/caom2-artifact-resolvers/src/main/java/ca/nrc/cadc/caom2/artifact/resolvers/CaomArtifactResolver.java
@@ -158,7 +158,7 @@ public class CaomArtifactResolver {
         // default
         setAuthMethod(AuthenticationUtil.getAuthMethod(AuthenticationUtil.getCurrentSubject()));
     }
-
+    
     /**
      * Override the authentication method from the current subject in order to generate URLs
      * with a possibly different authentication method. This override may not be applicable
@@ -194,7 +194,12 @@ public class CaomArtifactResolver {
         }
     }
 
-    private StorageResolver getStorageResolver(final URI uri) {
+    /**
+     * Instantiate a StorageResolver based on the URI provided.
+     * @param uri URI containing the scheme necessary to instantiate the resolver
+     * @return A StorageResolver instance
+     */
+    public StorageResolver getStorageResolver(final URI uri) {
         final StorageResolver storageResolver = handlers.get(uri.getScheme());
 
         if (storageResolver != null) {


### PR DESCRIPTION
This fix adds the CadcAlmaResolver to the CaomArtifactResolver.properites file so that ALMA URI's can be resolved. Along with this change, some codes have been refactored resulting in files being updated and moved. The following is a list of modules updated as a result of this fix.
caom2service/caom2-tap
caom2service/caom2-datalink-server
caom2service/caom2-pkg-server
caom2service/caom2-soda-server
caom2/caom2-artifact-resolvers
caom2sandbox/sc2links
caom2sandbox/sc2soda