### PR TITLE
Change dependencies with "plus" to maven compliant syntax.

### DIFF
--- a/caom2-compute/build.gradle
+++ b/caom2-compute/build.gradle
@@ -15,16 +15,16 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.16'
+version = '2.3.17'
 
 dependencies {
-    compile 'log4j:log4j:1.2.+'
+    compile 'log4j:log4j:[1.2.0,)'
     
-    compile 'org.opencadc:cadc-util:1.+'
+    compile 'org.opencadc:cadc-util:[1,2)'
     compile 'org.opencadc:caom2:[2.3.6,)'
     compile 'org.opencadc:cadc-wcs:[2.0,)'
 
-    testCompile group: 'junit', name: 'junit', version: '4.+'
+    testCompile group: 'junit', name: 'junit', version: '[4,5)'
 }
 
 apply from: '../opencadc.gradle'

--- a/caom2-dm/build.gradle
+++ b/caom2-dm/build.gradle
@@ -12,7 +12,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '2.4.1'
+version = '2.4'
 
 jar {
     enabled = true

--- a/caom2-dm/build.gradle
+++ b/caom2-dm/build.gradle
@@ -12,7 +12,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '2.4'
+version = '2.4.1'
 
 jar {
     enabled = true
@@ -50,5 +50,5 @@ xslt {
 dependencies {
     testCompile 'org.opencadc:cadc-vodml:[1.0.4,)'
 
-    testCompile 'junit:junit:4.+' 
+    testCompile 'junit:junit:[4,5)' 
 }

--- a/caom2-validator/build.gradle
+++ b/caom2-validator/build.gradle
@@ -16,13 +16,13 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.4'
+version = '2.3.5'
 
 mainClassName = "ca.nrc.cadc.caom2.Main"
 
 dependencies {
-    compile 'log4j:log4j:1.2.+'
-    compile 'org.jdom:jdom2:2.+'
+    compile 'log4j:log4j:[1.2,1.3)'
+    compile 'org.jdom:jdom2:[2,3)'
     
     compile 'org.opencadc:cadc-util:[1.0,2.0)'
     compile 'org.opencadc:caom2:[2.3.17,2.4)'

--- a/caom2-viz/build.gradle
+++ b/caom2-viz/build.gradle
@@ -15,19 +15,19 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '0.3'
+version = '0.3.1'
 
 mainClassName = 'ca.nrc.cadc.caom2.viz.Main'
 
 dependencies {
-    compile 'log4j:log4j:1.2.+'
-    compile 'org.jdom:jdom2:2.+'
+    compile 'log4j:log4j:[1.2,1.3)'
+    compile 'org.jdom:jdom2:[2,3)'
     
-    compile 'org.opencadc:cadc-util:1.+'
+    compile 'org.opencadc:cadc-util:[1,2)'
     compile 'org.opencadc:caom2:[2.3.4,)'
     compile 'org.opencadc:caom2-compute:[2.3.3,)'
     
-    testCompile 'junit:junit:4.+'
+    testCompile 'junit:junit:[4,5)'
 }
 
 configurations {

--- a/fits2caom2/build.gradle
+++ b/fits2caom2/build.gradle
@@ -15,21 +15,21 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.2'
+version = '2.3.3'
 
 mainClassName = 'ca.nrc.cadc.fits2caom2.Main'
 
 dependencies {
-    compile 'log4j:log4j:1.2.+'
-    compile 'org.jdom:jdom2:2.+'
-    compile 'gov.nasa.gsfc.heasarc:nom-tam-fits:1.+'
+    compile 'log4j:log4j:[1.2,1.3)'
+    compile 'org.jdom:jdom2:[2,3)'
+    compile 'gov.nasa.gsfc.heasarc:nom-tam-fits:[1,2)'
     
-    compile 'org.opencadc:cadc-util:1.+'
+    compile 'org.opencadc:cadc-util:[1,2)'
     compile 'org.opencadc:caom2:[2.3.14,2.4.0)'
-    compile 'org.opencadc:cadc-registry:1.+'
-    compile 'org.opencadc:cadc-vos:1.+'
+    compile 'org.opencadc:cadc-registry:[1,2)'
+    compile 'org.opencadc:cadc-vos:[1,2)'
 
-    testCompile 'junit:junit:4.+'
+    testCompile 'junit:junit:[4,5)'
 }
 
 configurations {

--- a/opencadc.gradle
+++ b/opencadc.gradle
@@ -4,7 +4,7 @@ configurations {
 
 dependencies {
     testCompile 'com.puppycrawl.tools:checkstyle:8.2'
-    checkstyleDep 'org.opencadc:cadc-quality:1.+'
+    checkstyleDep 'org.opencadc:cadc-quality:[1,2)'
 }
 
 checkstyle {


### PR DESCRIPTION
ESDC is migrating all its projects to Maven. In this process it has been found that some dependencies from CADC CAOM software are failing due to dependencies defined with a plus sign ("+"). In this branch, all this kind of dependencies has been changed to a maven valid syntax. For instance:
From:
compile 'log4j:log4j:1.2.+'
To:
compile 'log4j:log4j:[1.2,1.3)'