### PR TITLE
Dependencies versions review

### DIFF
--- a/caom2-artifact-resolvers/build.gradle
+++ b/caom2-artifact-resolvers/build.gradle
@@ -15,15 +15,15 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.1.17'
+version = '1.1.18'
 
 dependencies {
-    compile 'log4j:log4j:[1.2.0,)'
+    compile 'log4j:log4j:1.2.17'
 
-    compile 'org.opencadc:cadc-util:[1.1,)'
-    compile 'org.opencadc:cadc-registry:[1.0,)'
+    compile 'org.opencadc:cadc-util:[1.2.3,1.3)'
+    compile 'org.opencadc:cadc-registry:[1.5,1.6)'
 
-    testCompile 'junit:junit:[4.0,)'
+    testCompile 'junit:junit:4.10'
 }
 
 // enable intTest

--- a/caom2-artifact-resolvers/build.gradle
+++ b/caom2-artifact-resolvers/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compile 'org.opencadc:cadc-util:[1.2.3,1.3)'
     compile 'org.opencadc:cadc-registry:[1.5,1.6)'
 
-    testCompile 'junit:junit:4.10'
+    testCompile 'junit:junit:4.13'
 }
 
 // enable intTest

--- a/caom2-compute/build.gradle
+++ b/caom2-compute/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     compile 'org.opencadc:caom2:[2.4,2.5)'
     compile 'org.opencadc:cadc-wcs:[2,3)'
 
-    testCompile group: 'junit', name: 'junit', version: '4.10'
+    testCompile group: 'junit', name: 'junit', version: '4.13'
 }
 
 apply from: '../opencadc.gradle'

--- a/caom2-compute/build.gradle
+++ b/caom2-compute/build.gradle
@@ -18,13 +18,13 @@ group = 'org.opencadc'
 version = '2.4.3'
 
 dependencies {
-    compile 'log4j:log4j:[1.2.0,)'
+    compile 'log4j:log4j:1.2.17'
     
-    compile 'org.opencadc:cadc-util:[1,2)'
-    compile 'org.opencadc:caom2:[2.4.0,2.5.0)'
-    compile 'org.opencadc:cadc-wcs:[2.0,3.0)'
+    compile 'org.opencadc:cadc-util:[1.2.3,1.3)'
+    compile 'org.opencadc:caom2:[2.4,2.5)'
+    compile 'org.opencadc:cadc-wcs:[2,3)'
 
-    testCompile group: 'junit', name: 'junit', version: '[4,5)'
+    testCompile group: 'junit', name: 'junit', version: '4.10'
 }
 
 apply from: '../opencadc.gradle'

--- a/caom2-dm/build.gradle
+++ b/caom2-dm/build.gradle
@@ -12,7 +12,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '2.4.1'
+version = '2.4'
 
 jar {
     enabled = true

--- a/caom2-dm/build.gradle
+++ b/caom2-dm/build.gradle
@@ -12,7 +12,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '2.4'
+version = '2.4.1'
 
 jar {
     enabled = true
@@ -48,7 +48,7 @@ xslt {
 }
 
 dependencies {
-    testCompile 'org.opencadc:cadc-vodml:[1.0.4,)'
+    testCompile 'org.opencadc:cadc-vodml:[1.0.4,1.1)'
 
-    testCompile 'junit:junit:[4,5)' 
+    testCompile 'junit:junit:4.10' 
 }

--- a/caom2-dm/build.gradle
+++ b/caom2-dm/build.gradle
@@ -50,5 +50,5 @@ xslt {
 dependencies {
     testCompile 'org.opencadc:cadc-vodml:[1.0.4,1.1)'
 
-    testCompile 'junit:junit:4.10' 
+    testCompile 'junit:junit:4.13' 
 }

--- a/caom2-validator/build.gradle
+++ b/caom2-validator/build.gradle
@@ -16,17 +16,17 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.4.0'
+version = '2.4.1'
 
 mainClassName = "ca.nrc.cadc.caom2.Main"
 
 dependencies {
-    compile 'log4j:log4j:[1.2,1.3)'
-    compile 'org.jdom:jdom2:[2,3)'
+    compile 'log4j:log4j:1.2.17'
+    compile 'org.jdom:jdom2:2.0.6'
     
-    compile 'org.opencadc:cadc-util:[1.0,2.0)'
-    compile 'org.opencadc:caom2:[2.4.0,2.5.0)'
-    compile 'org.opencadc:caom2-compute:[2.4.0,2.5.0)'
+    compile 'org.opencadc:cadc-util:[1.0,1.3)'
+    compile 'org.opencadc:caom2:[2.4.0,2.5)'
+    compile 'org.opencadc:caom2-compute:[2.4,2.5)'
 }
 
 apply from: '../opencadc.gradle'

--- a/caom2-viz/build.gradle
+++ b/caom2-viz/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     compile 'org.opencadc:caom2:[2.4,2.5)'
     compile 'org.opencadc:caom2-compute:[2.4,2.5)'
     
-    testCompile 'junit:junit:4.10'
+    testCompile 'junit:junit:4.13'
 }
 
 configurations {

--- a/caom2-viz/build.gradle
+++ b/caom2-viz/build.gradle
@@ -15,19 +15,19 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '0.4'
+version = '0.5'
 
 mainClassName = 'ca.nrc.cadc.caom2.viz.Main'
 
 dependencies {
-    compile 'log4j:log4j:[1.2,1.3)'
-    compile 'org.jdom:jdom2:[2,3)'
+    compile 'log4j:log4j:1.2.17'
+    compile 'org.jdom:jdom2:2.0.6'
     
-    compile 'org.opencadc:cadc-util:[1,2)'
-    compile 'org.opencadc:caom2:[2.4.0,2.5.0)'
-    compile 'org.opencadc:caom2-compute:[2.4.0,2.5.0)'
+    compile 'org.opencadc:cadc-util:[1,1.3)'
+    compile 'org.opencadc:caom2:[2.4,2.5)'
+    compile 'org.opencadc:caom2-compute:[2.4,2.5)'
     
-    testCompile 'junit:junit:[4,5)'
+    testCompile 'junit:junit:4.10'
 }
 
 configurations {

--- a/caom2/build.gradle
+++ b/caom2/build.gradle
@@ -16,15 +16,15 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.4.1'
+version = '2.4.2'
 
 dependencies {
-    compile 'log4j:log4j:[1.2,)'
-    compile 'org.jdom:jdom2:[2.0,)'
+    compile 'log4j:log4j:1.2.17'
+    compile 'org.jdom:jdom2:2.0.6'
     
-    compile 'org.opencadc:cadc-util:[1.2,)'
+    compile 'org.opencadc:cadc-util:[1.2.3,1.3)'
 
-    testCompile 'junit:junit:[4.0,5.0)'
+    testCompile 'junit:junit:4.10'
 }
 
 configurations {

--- a/caom2/build.gradle
+++ b/caom2/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     
     compile 'org.opencadc:cadc-util:[1.2.3,1.3)'
 
-    testCompile 'junit:junit:4.10'
+    testCompile 'junit:junit:4.13'
 }
 
 configurations {

--- a/fits2caom2/build.gradle
+++ b/fits2caom2/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     compile 'org.opencadc:cadc-registry:[1,2)'
     compile 'org.opencadc:cadc-vos:[1,2)'
 
-    testCompile 'junit:junit:[4,5)'
+    testCompile 'junit:junit:4.13'
 }
 
 configurations {


### PR DESCRIPTION
General rules applied:
Third party libraries to fix version.
Add max version to CAOM libraries in the form of: [x.y, x.y+1)