### PR TITLE
Remove encoding for toURL URLs to protect from double encoding by the…

### DIFF
--- a/caom2-artifact-resolvers/build.gradle
+++ b/caom2-artifact-resolvers/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.2.3'
+version = '1.2.4'
 
 description = 'OpenCADC CAOM artifact resolvers library'
 def git_url = 'https://github.com/opencadc/caom2'

--- a/caom2-artifact-resolvers/src/main/java/ca/nrc/cadc/caom2/artifact/resolvers/SubaruResolver.java
+++ b/caom2-artifact-resolvers/src/main/java/ca/nrc/cadc/caom2/artifact/resolvers/SubaruResolver.java
@@ -89,10 +89,10 @@ public class SubaruResolver implements StorageResolver {
     private static final String RAW_DATA_URI = "raw";
     private static final String PREVIEW_URI = "preview";
 
-    private static final String BASE_DATA_URL = "http://www.canfar.net/maq/subaru?frameinfo=";
+    private static final String BASE_DATA_URL = "https://www.canfar.net/maq/subaru?frameinfo=";
 
     // Suprime-Cam
-    private static final String PREVIEW_BASE_URL = "http://smoka.nao.ac.jp";
+    private static final String PREVIEW_BASE_URL = "https://smoka.nao.ac.jp";
     private static final String PREVIEW_URL_PATH = "/qlis/ImagePNG";
     private static final String PREVIEW_URL_QUERY = "grayscale=linear&mosaic=true&frameid=";
 
@@ -170,7 +170,7 @@ public class SubaruResolver implements StorageResolver {
             // expected URI input is subaru:raw/YYYY-MM-dd/<FRAMEID>
             // expected URL output is http://www.canfar.net
             // /maq/subaru?frameinfo=YYYY-MM-dd/FRAMEID
-            sb = BASE_DATA_URL + NetUtil.encode(path[1] + "/" + path[2]);
+            sb = BASE_DATA_URL + path[1] + "/" + path[2];
         } else {
             throw new IllegalArgumentException("Invalid URI: " + requestType);
         }

--- a/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/SubaruResolverTest.java
+++ b/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/SubaruResolverTest.java
@@ -95,11 +95,10 @@ public class SubaruResolverTest {
     String VALID_HSC_FRAMEID = "HSCA069890XX";
     String EXPECTED_HSC_FILENAME = "HSCA069890.png";
 
-    String SCHEME = "subaru";
     String RAW_DATA_URI = "raw";
     String PREVIEW_URI = "preview";
 
-    String PROTOCOL_STR = "http://";
+    String PROTOCOL_STR = "https://";
 
     String BASE_PREVIEW_URL = "smoka.nao.ac.jp";
     String PREVIEW_URL_QUERY = "grayscale=linear&mosaic=true&frameid=";
@@ -126,15 +125,17 @@ public class SubaruResolverTest {
     @Test
     public void testValidRawURI() throws Exception {
         try {
-            String uriStr = subaruResolver.getScheme() + ":" + RAW_DATA_URI + "/" + VALID_DATE1 + "/" + VALID_SUP_FRAMEID;
+            String uriStr = subaruResolver.getScheme() + ":" + RAW_DATA_URI + "/" + VALID_DATE1 + "/"
+                            + VALID_SUP_FRAMEID;
             URI uri = new URI(uriStr);
             URL url = subaruResolver.toURL(uri);
             log.debug("toURL returned: " + url.toString());
 
-            String encodedValue = NetUtil.encode(VALID_DATE1 + "/" + VALID_SUP_FRAMEID);
-            Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_DATA_URL + DATA_URL_PATH + "?" + DATA_URL_QUERY +  encodedValue);
+            String frameQueryValue = VALID_DATE1 + "/" + VALID_SUP_FRAMEID;
+            Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_DATA_URL + DATA_URL_PATH + "?"
+                                                + DATA_URL_QUERY +  frameQueryValue);
             Assert.assertEquals(DATA_URL_PATH, url.getPath());
-            Assert.assertEquals(DATA_URL_QUERY + encodedValue, url.getQuery());
+            Assert.assertEquals(DATA_URL_QUERY + frameQueryValue, url.getQuery());
             Assert.assertEquals(BASE_DATA_URL, url.getHost());
 
         } catch (Exception unexpected) {
@@ -148,14 +149,16 @@ public class SubaruResolverTest {
     public void testValidHSCPreviewURI() throws Exception {
         log.debug("START - testValidHSCPreviewURI");
         try {
-            String uriStr = subaruResolver.getScheme() + ":" + PREVIEW_URI + "/" + VALID_DATE2 + "/" + VALID_HSC_FRAMEID;
+            String uriStr = subaruResolver.getScheme() + ":" + PREVIEW_URI + "/" + VALID_DATE2 + "/"
+                            + VALID_HSC_FRAMEID;
             URI uri = new URI(uriStr);
             log.debug("HSC URI: " + uriStr);
             URL url = subaruResolver.toURL(uri);
             log.debug("toURL returned: " + url.toString());
 
             String fileSpecificPart = VALID_DATE2 + "/" + EXPECTED_HSC_FILENAME;
-            Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_PREVIEW_URL + HSC_PREVIEW_URL_PATH + "/" +  fileSpecificPart);
+            Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_PREVIEW_URL + HSC_PREVIEW_URL_PATH + "/"
+                                                + fileSpecificPart);
             Assert.assertEquals(HSC_PREVIEW_URL_PATH + "/" + fileSpecificPart, url.getPath());
             Assert.assertEquals(BASE_PREVIEW_URL, url.getHost());
 
@@ -184,7 +187,8 @@ public class SubaruResolverTest {
     @Test
     public void testValidSUPPreviewURI() {
         try {
-            final String uriStr = subaruResolver.getScheme() + ":" + PREVIEW_URI + "/" + VALID_DATE1 + "/" + VALID_SUP_FRAMEID2;
+            final String uriStr = subaruResolver.getScheme() + ":" + PREVIEW_URI + "/" + VALID_DATE1 + "/"
+                                  + VALID_SUP_FRAMEID2;
             final URI uri = URI.create(uriStr);
             final URL url = subaruResolver.toURL(uri);
 
@@ -215,7 +219,8 @@ public class SubaruResolverTest {
 
             log.debug("toURL returned: " + url.toString());
 
-            Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_PREVIEW_URL + PREVIEW_URL_PATH + "?" + PREVIEW_URL_QUERY + VALID_SUP_FRAMEID2);
+            Assert.assertEquals(url.toString(), PROTOCOL_STR + BASE_PREVIEW_URL + PREVIEW_URL_PATH + "?"
+                                                + PREVIEW_URL_QUERY + VALID_SUP_FRAMEID2);
             Assert.assertEquals(PREVIEW_URL_PATH, url.getPath());
             Assert.assertEquals(PREVIEW_URL_QUERY + VALID_SUP_FRAMEID2, url.getQuery());
             Assert.assertEquals(BASE_PREVIEW_URL, url.getHost());

--- a/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/VOSpaceResolverTest.java
+++ b/caom2-artifact-resolvers/src/test/java/ca/nrc/cadc/caom2/artifact/resolvers/VOSpaceResolverTest.java
@@ -89,8 +89,8 @@ public class VOSpaceResolverTest {
         Log4jInit.setLevel("ca.nrc.cadc", Level.INFO);
     }
 
-    private static final String FILE_URI = "vos://cadc.nrc.ca!vospace/FOO/bar";
-    private static final String INVALID_SCHEME_URI1 = "ad://cadc.nrc.ca!vospace/FOO/bar";
+    private static final String FILE_URI = "vos://cadc.nrc.ca!vault/FOO/bar";
+    private static final String INVALID_SCHEME_URI1 = "ad://cadc.nrc.ca!vault/FOO/bar";
     private static final String INVALID_NO_AUTHORITY_URI1 = "vos:/FOO";
 
     VOSpaceResolver vosResolver = new VOSpaceResolver();


### PR DESCRIPTION
… browser.
Small fix to VOSpaceResolverTest to use `vault` rather than `vospace` to avoid the CANFAR phys.uvic.ca URLs.