### PR TITLE
ONYX-20 | Added Permissions API path for check permissions

### DIFF
--- a/torkeep/src/main/java/org/opencadc/torkeep/RepoAction.java
+++ b/torkeep/src/main/java/org/opencadc/torkeep/RepoAction.java
@@ -506,13 +506,16 @@ public abstract class RepoAction extends RestAction {
         AuthorizationToken tok = getAuthorizationToken(subject);
         if (tok != null && authAPI != null && permAPI != null) {
             String srv = PAPI_SRV;
-            String route = "/observations/" + syncInput.getPath();
-            log.debug("call papi: " + permAPI + " service=" + srv + " route=" + route + " method=" + method);
+            String route = "/observations/{collection}/{observationID}";
+            final JSONObject jsonBody = new JSONObject();
+            jsonBody.put("collection", getCollection());
+            jsonBody.put("observationID", getObservationURI() != null ? getObservationURI().toASCIIString() : null);
+            log.debug("call papi: " + permAPI + " service=" + srv + " route=" + route + " body=" + jsonBody + " method=" + method);
             PermissionsAPIClient permissionsAPIClient = new PermissionsAPIClient(permAPI.toURL(), authAPI.toURL());
             AuthorisationResult authorisationResult = permissionsAPIClient.authoriseRoute(
-                    srv, route, 
+                    srv, route,
                     tok.getCredentials(), // ignores token domains and scope
-                    method, null, "1");
+                    method, jsonBody, "1");
             log.debug("papi: authorised=" + authorisationResult.isAuthorised + " route=" + route);
             if (authorisationResult.isAuthorised) {
                 logInfo.setResource(grantURI);


### PR DESCRIPTION
Torkeep write authorization was failing against the Permissions API because write requests were sent using the concrete request path instead of the templated route expected by policy.

## Problem
GET requests succeed because they use the templated route:
`/observations/{collection}`

But PUT/POST/DELETE used:
`/observations/<collection>/<observationID>`

The Permissions API policy expects:
`/observations/{collection}/{observationID}`

Because the route key did not match the configured policy, write authorization failed.

## Fix
Update `RepoAction.checkWritePermission` to:
- use the templated route `/observations/{collection}/{observationID}`
- send `collection` and `observationID` in the request body passed to `authoriseRoute`

## Result
Write authorization now matches the configured Permissions API policy for:
- `PUT`
- `POST`
- `DELETE`